### PR TITLE
Fix Gemini schema compatibility and upgrade to gemini-2.5-flash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
       - AI_AGENT_PORT=8001
-      - AI_MODEL=gemini-2.5-flash-lite
+      - AI_MODEL=${AI_MODEL}
       - MCP_SERVER_URL=http://mcp-server:8002
       - MAX_CONVERSATION_LENGTH=15
       - ENVIRONMENT=development

--- a/mcp-server/src/schemas/__init__.py
+++ b/mcp-server/src/schemas/__init__.py
@@ -1,0 +1,20 @@
+"""
+Pydantic schemas for MCP tool parameters.
+
+These schemas ensure Gemini compatibility by using explicit Pydantic models
+instead of Dict[str, Any], which Gemini's function calling doesn't support.
+"""
+
+from .tool_parameters import (
+    WorkflowCustomization,
+    PermissionUpdate,
+    FormField,
+    WorkflowAction,
+)
+
+__all__ = [
+    "WorkflowCustomization",
+    "PermissionUpdate",
+    "FormField",
+    "WorkflowAction",
+]

--- a/mcp-server/src/schemas/tool_parameters.py
+++ b/mcp-server/src/schemas/tool_parameters.py
@@ -1,0 +1,131 @@
+"""
+Pydantic models for MCP tool parameters.
+
+These models replace Dict[str, Any] parameters to ensure compatibility with
+Google Gemini's function calling API, which doesn't support additionalProperties.
+
+Following best practices from:
+- Google Gemini function calling docs
+- Pydantic AI type safety guidelines
+- MCP protocol standardization
+"""
+
+from typing import Optional, List, Literal
+from pydantic import BaseModel, Field
+
+
+class WorkflowCustomization(BaseModel):
+    """
+    Customizations for workflow templates.
+
+    Allows modifying template workflows by adding or removing states/actions
+    without using dynamic dict structures that Gemini can't handle.
+    """
+    additional_states: Optional[List[str]] = Field(
+        default=None,
+        description="Additional states to add to the template workflow"
+    )
+    additional_actions: Optional[List[str]] = Field(
+        default=None,
+        description="Additional actions/transitions to add to the workflow"
+    )
+    skip_states: Optional[List[str]] = Field(
+        default=None,
+        description="States from template to skip/exclude"
+    )
+    description_override: Optional[str] = Field(
+        default=None,
+        description="Override the template's default description"
+    )
+
+    class Config:
+        """Pydantic config for Gemini compatibility."""
+        extra = "forbid"  # Prevent additionalProperties in JSON schema
+
+
+class PermissionUpdate(BaseModel):
+    """
+    Permission update specification for workflow access control.
+
+    Defines who can perform actions in the workflow using explicit structure
+    instead of dict[str, str] which Gemini doesn't support.
+    """
+    slug: str = Field(
+        description="Permission identifier (e.g., 'manager_approval_perm')"
+    )
+    description: str = Field(
+        description="Human-readable permission description"
+    )
+
+    class Config:
+        """Pydantic config for Gemini compatibility."""
+        extra = "forbid"  # Prevent additionalProperties in JSON schema
+
+
+class FormField(BaseModel):
+    """
+    Form field specification for workflow data collection.
+
+    Defines input fields for workflow actions that require user data.
+    Uses explicit typing instead of dynamic dicts for Gemini compatibility.
+    """
+    key: str = Field(
+        description="Field identifier/name"
+    )
+    type: Literal["string", "date", "number", "boolean", "select"] = Field(
+        description="Field data type"
+    )
+    required: bool = Field(
+        default=False,
+        description="Whether field is mandatory"
+    )
+    options: Optional[List[str]] = Field(
+        default=None,
+        description="Available options for select fields"
+    )
+    label: Optional[str] = Field(
+        default=None,
+        description="Human-readable field label"
+    )
+
+    class Config:
+        """Pydantic config for Gemini compatibility."""
+        extra = "forbid"  # Prevent additionalProperties in JSON schema
+
+
+class WorkflowAction(BaseModel):
+    """
+    Workflow action/transition specification.
+
+    Defines state transitions in the workflow using explicit Pydantic model
+    instead of Dict[str, Any] for Gemini function calling compatibility.
+    """
+    slug: str = Field(
+        description="Action identifier (e.g., 'submit_for_review')"
+    )
+    from_state: str = Field(
+        alias="from",
+        description="Source state slug"
+    )
+    to_state: str = Field(
+        alias="to",
+        description="Destination state slug"
+    )
+    permission: str = Field(
+        description="Required permission slug for this action"
+    )
+    requires_form: bool = Field(
+        default=False,
+        alias="requiresForm",
+        description="Whether this action requires a form to be filled"
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Human-readable action name"
+    )
+
+    class Config:
+        """Pydantic config for Gemini compatibility and camelCase support."""
+        populate_by_name = True
+        allow_population_by_field_name = True
+        extra = "forbid"  # Prevent additionalProperties in JSON schema


### PR DESCRIPTION
Root Cause:
- Gemini's function calling API doesn't support 'additionalProperties' in JSON schemas
- MCP tools using Dict[str, Any] generated incompatible schemas
- Pydantic AI bug #1469: wraps Optional[Model] with additionalProperties: True
- Both Spanish and English workflows were affected (not language-specific)

Solution:
1. Created Gemini-compatible Pydantic models with explicit fields
   - WorkflowCustomization: Template customization parameters
   - PermissionUpdate: Workflow permission specifications
   - FormField: Form field definitions
   - WorkflowAction: Workflow action/transition specs
   - All models use 'extra = "forbid"' to prevent additionalProperties

2. Updated MCP tool signatures to use Pydantic models:
   - workflow_creation.py: create_workflow_from_template
   - workflow_updates.py: update_workflow_permissions, configure_workflow_forms
   - state_management.py: update_workflow_actions
   - Added model_dump(by_alias=True) conversions for API compatibility

3. Upgraded AI model for better schema handling:
   - Changed from gemini-2.5-flash-lite to gemini-2.5-flash
   - Updated docker-compose.yml to use ${AI_MODEL} from .env
   - Eliminates 'additionalProperties' warnings completely

Results:
✅ Both Spanish and English workflow creation working ✅ Zero schema compatibility warnings
✅ Follows Google Gemini best practices (use Pydantic models vs dicts) ✅ Future-proof solution compatible with all LLM providers

Testing:
- Rebuilt all services with updated code
- Verified Spanish workflow creation ("Flujo de trabajo simple")
- Confirmed no additionalProperties warnings in logs
- Backend API tests passed