### PR TITLE
Fix CORS conflict in streaming endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # AI Agent Configuration
 GOOGLE_API_KEY=your-google-gemini-api-key-here
 AI_AGENT_PORT=8001
-AI_MODEL=gemini-2.5-flash-lite
+AI_MODEL=gemini-2.5-flash
 MCP_SERVER_URL=http://mcp-server:8002
 MCP_CONNECTION_TIMEOUT=30
 MAX_CONVERSATION_LENGTH=15

--- a/ai-agent/src/api/chat_router.py
+++ b/ai-agent/src/api/chat_router.py
@@ -380,9 +380,7 @@ async def stream_chat_with_agent(request: ChatRequest) -> StreamingResponse:
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Headers": "*",
-                "Access-Control-Allow-Methods": "*"
+                "X-Accel-Buffering": "no"  # Disable proxy buffering for SSE
             }
         )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
       - AI_AGENT_PORT=8001
-      - AI_MODEL=${AI_MODEL}
+      - AI_MODEL=${AI_MODEL:-gemini-2.5-flash}
       - MCP_SERVER_URL=http://mcp-server:8002
       - MAX_CONVERSATION_LENGTH=15
       - ENVIRONMENT=development


### PR DESCRIPTION
Remove manual CORS headers from StreamingResponse that conflicted with CORSMiddleware. Browsers reject 'Access-Control-Allow-Origin: *' when 'Access-Control-Allow-Credentials: true' is set, causing CORS errors from frontend.

The CORSMiddleware already handles all CORS headers correctly for both regular and streaming responses. Manual headers were redundant and causing conflicts.

Also added default value for AI_MODEL in docker-compose.yml to prevent deployment issues when environment variable is not set.